### PR TITLE
Allow triggers on schema not declared by package

### DIFF
--- a/object.go
+++ b/object.go
@@ -90,7 +90,7 @@ func (s *Statement) getTriggerObject() (*ManagedObject, error) {
 	}
 
 	if !pkg.isValidSchema(schema) {
-		return nil, PKGErrorf(s, nil, "trigger table schema %s is not declared in package", schema)
+		fmt.Printf("WARNING: the schema '%s' for trigger '%s' is not declared in package '%s'; continuing anyway\n", schema, name, pkg.Name)
 	}
 
 	return &ManagedObject{


### PR DESCRIPTION
I'm working in an old code base with a large existing database schema. I need to be able to write triggers on tables in the existing schema. Since triggers are always created in the same schema as their table, pgpkg refuses to create triggers on tables in schemas outside of the package. This is a severe limitation for me.

Perhaps pgpkg could allow for some configuration in the toml file to clearly whitelist tables in other schemas, or something like that, if this is deemed to risky.